### PR TITLE
add checks for pyear start and stop

### DIFF
--- a/src/facts_total/cli.py
+++ b/src/facts_total/cli.py
@@ -20,19 +20,19 @@ from facts_total.total_workflow import WorkflowTotaler
     "--pyear-start",
     type=int,
     required=True,
-    help="Enter the pyear-start value used for the individual modules. If modules used different pyear-start values, enter the one you would like used for the totaled output."
+    help="Enter the pyear-start value used for the individual modules. If modules used different pyear-start values, enter the one you would like used for the totaled output.",
 )
 @click.option(
     "--pyear-end",
     type=int,
     required=True,
-    help="Enter the pyear-end value used for the individual modules. If modules used different pyear-end values, enter the one you would like used for the totaled output."
+    help="Enter the pyear-end value used for the individual modules. If modules used different pyear-end values, enter the one you would like used for the totaled output.",
 )
 @click.option(
     "--pyear-step",
     type=int,
     required=True,
-    help="Enter the pyear-step value used for the individual modules. If modules used different pyear-step values, enter the one you would like used for the totaled output."
+    help="Enter the pyear-step value used for the individual modules. If modules used different pyear-step values, enter the one you would like used for the totaled output.",
 )
 @click.option(
     "--output-path",
@@ -40,12 +40,7 @@ from facts_total.total_workflow import WorkflowTotaler
     required=True,
     help="Path to write totaled projections netcdf file.",
 )
-def main(name,
-        item, 
-        output_path,
-        pyear_start,
-        pyear_end,
-        pyear_step):
+def main(name, item, output_path, pyear_start, pyear_end, pyear_step):
     click.echo("Hello from FACTS totaling!")
 
     # Make list of input paths

--- a/src/facts_total/total_workflow.py
+++ b/src/facts_total/total_workflow.py
@@ -74,20 +74,23 @@ class WorkflowTotaler:
             xr.Dataset
                 Dataset with added 'file' dimension and transposed dimensions.
             """
-            
-            #check this files dims against the provided pyear values
+
+            # check this files dims against the provided pyear values
             pyear_start = self.pyear_start
             pyear_end = self.pyear_end
             pyear_step = self.pyear_step
 
-            if ds['years'].min().item() != pyear_start or ds['years'].max().item() != pyear_end:
+            if (
+                ds["years"].min().item() != pyear_start
+                or ds["years"].max().item() != pyear_end
+            ):
                 message = click.wrap_text(
                     f"⚠️ ⚠️ Warning ⚠️ ⚠️: The dataset being processed has a years dimension from {ds['years'].min().item()} to {ds['years'].max().item()}, which does not match the provided pyear-start ({pyear_start}) and pyear-end ({pyear_end}). Subsetting dataset to provided pyear values.",
                     width=70,
                 )
                 ds = ds.sel(years=slice(pyear_start, pyear_end))
 
-            step = ds['years'].diff('years')
+            step = ds["years"].diff("years")
             if len(np.unique(step.data)) != 1 or np.unique(step.data)[0] != pyear_step:
                 message = click.wrap_text(
                     f"⚠️ ⚠️ Warning ⚠️ ⚠️: The dataset being processed has a years dimension with step values {np.unique(step.data)}, which does not match the provided pyear-step ({pyear_step}). Check that you did not make a mistake specifying the totaling command or the individual modules.",


### PR DESCRIPTION
per discussion on 12/2, this PR adds logic to subset years dimension of module outputs to `pyear_start` and `pyear_stop` before totaling step. in some cases, the years dimension of a module output includes baseyear. this PR removes the baseyear element from the years dim before totaling to follow the behavior of in facts 1's [totaling step](https://github.com/radical-collaboration/facts/blob/main/modules/facts/total/total_workflow.py)