### PR TITLE
add fn to normalize dimension order + test

### DIFF
--- a/src/facts_total/total_workflow.py
+++ b/src/facts_total/total_workflow.py
@@ -8,6 +8,15 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+def normalize_slc_dim_order(ds: xr.Dataset) -> xr.Dataset:
+    canonical_dim_order = tuple(
+        ds[c].dims[0] for c in ("samples", "years", "locations") if c in ds
+    )
+    if set(canonical_dim_order) == set(ds["sea_level_change"].dims):
+        ds["sea_level_change"] = ds["sea_level_change"].transpose(*canonical_dim_order)
+    return ds
+
+
 class WorkflowTotaler:
     """
     Handles totaling of sealevel projections from modules included in a workflow.
@@ -132,6 +141,8 @@ class WorkflowTotaler:
             )
             ds["year_step"] = [np.unique(step.data)[0]]
 
+            # reorder dims
+            ds = normalize_slc_dim_order(ds)
             return ds
 
         assert hasattr(self, "paths_list"), (

--- a/tests/test_total_workflow.py
+++ b/tests/test_total_workflow.py
@@ -17,6 +17,7 @@ def make_dataset(dim_order):
         },
     )
 
+
 def test_normalize_dim_order_nonstandard():
     ds = make_dataset(("years", "samples", "locations"))
     result = normalize_slc_dim_order(ds)

--- a/tests/test_total_workflow.py
+++ b/tests/test_total_workflow.py
@@ -1,0 +1,38 @@
+from facts_total.total_workflow import normalize_slc_dim_order
+import numpy as np
+import xarray as xr
+
+
+def make_dataset(dim_order):
+    """Helper function to create minimal dataset"""
+
+    sizes = {"samples": 100, "years": 14, "locations": 1}
+    shape = [sizes[d] for d in dim_order]
+    return xr.Dataset(
+        {"sea_level_change": xr.DataArray(np.ones(shape), dims=dim_order)},
+        coords={
+            "samples": np.arange(100),
+            "years": np.arange(2020, 2161, 10),
+            "locations": np.array([12]),
+        },
+    )
+
+def test_normalize_dim_order_nonstandard():
+    ds = make_dataset(("years", "samples", "locations"))
+    result = normalize_slc_dim_order(ds)
+    assert result["sea_level_change"].dims == ("samples", "years", "locations")
+
+
+def test_normalize_dim_order_already_canonical():
+    ds = make_dataset(("samples", "years", "locations"))
+    result = normalize_slc_dim_order(ds)
+    assert result["sea_level_change"].dims == ("samples", "years", "locations")
+
+
+def test_normalize_dim_data_unchanged():
+    ds = make_dataset(("years", "locations", "samples"))
+    result = normalize_slc_dim_order(ds)
+    np.testing.assert_array_equal(
+        result["sea_level_change"].values,
+        ds["sea_level_change"].transpose("samples", "years", "locations").values,
+    )


### PR DESCRIPTION
This PR adds a process the re-orders dimensions of datasets passed to facts-total. Applies to datasets with `('samples','years','locations')` dims. This is a quick fix to https://github.com/fact-sealevel/facts-experiment-builder/issues/110. Will need to be updated when we change dimension names of module outputs and (possibly) drop the dummy locations dim